### PR TITLE
Fix icon transparency for Hide Completed and Hide Inactive tasks

### DIFF
--- a/taskcoachlib/tools/wxhelper.py
+++ b/taskcoachlib/tools/wxhelper.py
@@ -70,12 +70,11 @@ def clearAlphaDataOfImage(image: wx.Image, value: int):
     if not image.HasAlpha():
         image.InitAlpha()
 
-    # width = image.GetWidth()
-    # height = image.GetHeight()
+    width = image.GetWidth()
+    height = image.GetHeight()
 
-    alpha_data = image.GetAlpha()
-    alpha_array = np.frombuffer(alpha_data, dtype=np.uint8)
-    alpha_array.fill(value)
+    # Create a writable array filled with the value
+    alpha_array = np.full(width * height, value, dtype=np.uint8)
     image.SetAlpha(alpha_array.tobytes())
 
 


### PR DESCRIPTION
The "Hide Completed Task" and "Hide inactive tasks" toolbar icons had dark grey background squares instead of being transparent.

Root causes:
1. clearAlphaDataOfImage() used np.frombuffer() which creates a read-only array, making .fill() ineffective in Python 3
2. CreateBitmap() was clearing the main icon's alpha to 255 (fully opaque), destroying the original transparency

Fixes:
- Rewrote clearAlphaDataOfImage() to use np.full() to create a writable array
- Rewrote CreateBitmap() to preserve the original icon's alpha channel and properly merge it with the overlay's alpha channel