### PR TITLE
Fix widget resizing issues - prevent widgets from getting stuck at la…

### DIFF
--- a/taskcoachlib/gui/dialog/editor.py
+++ b/taskcoachlib/gui/dialog/editor.py
@@ -1265,8 +1265,9 @@ class EditBook(widgets.Notebook):
         for page_name in page_names:
             page = self.createPage(page_name, task_file, items_are_new)
             self.AddPage(page, page.pageTitle, page.pageIcon)
-        width, height = self.__get_minimum_page_size()
-        self.SetMinSize((width, self.GetHeightForPageHeight(height)))
+        # DISABLED: SetMinSize was locking entire notebook to max page size
+        # width, height = self.__get_minimum_page_size()
+        # self.SetMinSize((width, self.GetHeightForPageHeight(height)))
 
     def onPageChanged(self, event):
         self.GetPage(event.Selection).selected()
@@ -1405,7 +1406,9 @@ class EditBook(widgets.Notebook):
         perspective = self.perspective()
         if perspective:
             try:
-                self.LoadPerspective(perspective)
+                # DISABLED: LoadPerspective was restoring stale AuiNotebook perspective with broken sizing
+                # self.LoadPerspective(perspective)
+                pass
             except:  # pylint: disable=W0702
                 pass
         if items_are_new:

--- a/taskcoachlib/gui/viewer/base.py
+++ b/taskcoachlib/gui/viewer/base.py
@@ -209,7 +209,9 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
         self._sizer = wx.BoxSizer(wx.VERTICAL)  # pylint: disable=W0201
         self._sizer.Add(self.toolbar, flag=wx.EXPAND)
         self._sizer.Add(self.widget, proportion=1, flag=wx.EXPAND)
-        self.SetSizerAndFit(self._sizer)
+        self.SetSizer(self._sizer)  # Changed from SetSizerAndFit to prevent locking MinSize
+        # Prevent GetEffectiveMinSize() from returning child's BestSize
+        self.SetMinSize((100, 50))
 
     def createWidget(self, *args):
         raise NotImplementedError

--- a/taskcoachlib/widgets/listctrl.py
+++ b/taskcoachlib/widgets/listctrl.py
@@ -49,6 +49,8 @@ class VirtualListCtrl(
             *args,
             **kwargs
         )
+        # Override GetEffectiveMinSize() which returns BestSize - allows sizer to shrink widget
+        self.SetMinSize((100, 50))
         self.__parent = parent
         self.bindEventHandlers(selectCommand, editCommand)
 

--- a/taskcoachlib/widgets/notebook.py
+++ b/taskcoachlib/widgets/notebook.py
@@ -62,7 +62,7 @@ class BookPage(wx.Panel):
         self._borderWidth = 5
 
     def fit(self):
-        self.SetSizerAndFit(self._sizer)
+        self.SetSizer(self._sizer)  # Changed from SetSizerAndFit to prevent locking MinSize
 
     def __defaultFlags(self, controls):
         """Return the default flags for placing a list of controls."""


### PR DESCRIPTION
…rge sizes

This commit implements 6 fixes to resolve widget resizing problems:

Problem 1: Initial Layout Broken (Squashed ~200x200px)
- Disabled LoadPerspective() in editor.py:1408
- LoadPerspective was restoring stale AuiNotebook perspective with broken sizing

Problem 2: Widgets Growing But Not Shrinking
Fixed 4 layers where MinSize was being locked:

Fix 1: Viewer.initLayout() - base.py:212
- Changed SetSizerAndFit() → SetSizer()
- SetSizerAndFit was locking Viewer MinSize to widget's BestSize

Fix 2: BookPage.fit() - notebook.py:65
- Changed SetSizerAndFit() → SetSizer()
- SetSizerAndFit was locking BookPage MinSize affecting all widgets

Fix 3: EditBook.addPages() - editor.py:1268-1269
- Disabled SetMinSize() based on page sizes
- EditBook was calculating max(all page MinSizes) locking entire notebook

Fix 4: VirtualListCtrl.__init__() - listctrl.py:53
- Added SetMinSize((100, 50))
- Overrides GetEffectiveMinSize() which was returning BestSize (3021px)
- Allows sizer to shrink widget below inflated BestSize

Fix 5: Viewer.initLayout() - base.py:214
- Added SetMinSize((100, 50)) on Viewer panel
- Prevents GetEffectiveMinSize() from returning child's BestSize
- Allows BookPage's GridBagSizer to properly resize the Viewer