### PR TITLE
Fix command injection vulnerability in openFile

### DIFF
--- a/taskcoachlib/tools/openfile.py
+++ b/taskcoachlib/tools/openfile.py
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from taskcoachlib.thirdparty import desktop
 import platform
-import os
+import subprocess
 
 
 def openFile(filename):
@@ -26,7 +26,8 @@ def openFile(filename):
         desktop.open(filename)
     except OSError:
         if platform.system() == "Linux":
-            if os.system('xdg-open "%s"' % filename):
-                raise OSError('Unable to open "%s"')
+            result = subprocess.run(['xdg-open', filename], shell=False)
+            if result.returncode != 0:
+                raise OSError('Unable to open "%s"' % filename)
         else:
             raise


### PR DESCRIPTION
Replace os.system() with subprocess.run() to prevent shell metacharacter injection attacks. The vulnerable code allowed arbitrary command execution through malicious filenames containing shell metacharacters.