### PR TITLE
Fix bare except clauses across codebase

### DIFF
--- a/fixinit.py
+++ b/fixinit.py
@@ -23,8 +23,8 @@ def visitDir(arg, dirname, names):
     try:
         names.remove(".hg")
         names.remove(".git")
-    except:
-        pass
+    except ValueError:
+        pass  # .hg or .git not in list
 
     for name in names:
         if name in ["__init__.py", "itopicdefnprovider.py"]:

--- a/release.py
+++ b/release.py
@@ -310,7 +310,7 @@ def building_packages(settings, options):
     status = json.load(urllib.request.urlopen('http://%s:8010/json/builders/Release/builds/%d' % (host, buildno)))
     try:
         zipurl = status['steps'][-1]['urls']['Download release']
-    except:
+    except (KeyError, IndexError):
         raise RuntimeError('release.zip URL not found. Build failed.')
 
     if os.path.exists('dist'):

--- a/taskcoachlib/application/application.py
+++ b/taskcoachlib/application/application.py
@@ -230,8 +230,8 @@ class Application(object, metaclass=patterns.Singleton):
                 gnu_get_libc_version = libc.gnu_get_libc_version
                 gnu_get_libc_version.restype = ctypes.c_char_p
                 print(f"glibc {gnu_get_libc_version().decode()}")
-            except:
-                pass
+            except (OSError, AttributeError):
+                pass  # glibc version detection may fail
 
         # Log zeroconf version (used for iPhone sync)
         try:
@@ -457,8 +457,8 @@ class Application(object, metaclass=patterns.Singleton):
             from taskcoachlib.gui import taskbaricon  # pylint: disable=W0612
 
             return True
-        except:
-            return False  # pylint: disable=W0702
+        except ImportError:
+            return False  # TaskBarIcon not available on this platform
 
     @staticmethod
     def __close_splash(splash):

--- a/taskcoachlib/domain/date/scheduler.py
+++ b/taskcoachlib/domain/date/scheduler.py
@@ -115,8 +115,8 @@ class TwistedScheduler(object):
                 ts, job, interval = self.__jobs.pop(0)
                 try:
                     job()
-                except:
-                    # Hum.
+                except Exception:
+                    # Log exceptions from scheduled jobs but continue
                     import traceback
 
                     traceback.print_exc()

--- a/taskcoachlib/gui/dialog/editor.py
+++ b/taskcoachlib/gui/dialog/editor.py
@@ -1404,8 +1404,8 @@ class EditBook(widgets.Notebook):
                 # DISABLED: LoadPerspective was restoring stale AuiNotebook perspective with broken sizing
                 # self.LoadPerspective(perspective)
                 pass
-            except:  # pylint: disable=W0702
-                pass
+            except Exception:
+                pass  # Perspective loading may fail
         if items_are_new:
             current_page = (
                 self.getPageIndex("subject") or 0

--- a/taskcoachlib/gui/dialog/templates.py
+++ b/taskcoachlib/gui/dialog/templates.py
@@ -39,8 +39,8 @@ class TimeExpressionEntry(wx.TextCtrl):
         if value:
             try:
                 res = nlTimeExpression.parseString(value)
-            except:
-                return False  # pylint: disable=W0702
+            except Exception:
+                return False  # Parsing failed
             return "calculatedTime" in res
         return True  # Empty is valid.
 

--- a/taskcoachlib/gui/iocontroller.py
+++ b/taskcoachlib/gui/iocontroller.py
@@ -156,7 +156,7 @@ class IOController(object):
                     self.__taskFile.load(
                         filename, lock=lock, breakLock=breakLock
                     )
-                except:
+                except Exception:
                     # Need to destroy splash screen first because it may
                     # interfere with dialogs we show later on Mac OS X
                     if self.__splash:

--- a/taskcoachlib/gui/mainwindow.py
+++ b/taskcoachlib/gui/mainwindow.py
@@ -148,7 +148,7 @@ class MainWindow(
                 BonjourServiceRegister(
                     self.settings, acceptor.port
                 ).addCallbacks(success, error)
-            except:
+            except Exception:
                 from taskcoachlib.gui.dialog.iphone import IPhoneBonjourDialog
 
                 dlg = IPhoneBonjourDialog(self, wx.ID_ANY, _("Warning"))

--- a/taskcoachlib/gui/menu.py
+++ b/taskcoachlib/gui/menu.py
@@ -133,8 +133,8 @@ class DynamicMenu(Menu):
         # you must carefully check if the window already destroyed.
         try:  # Prepare for menu or window to be destroyed
             self.updateMenu()
-        except:
-            pass
+        except RuntimeError:
+            pass  # Menu or window may be destroyed
 
     def updateMenu(self):
         """Updating the menu consists of two steps: updating the menu item

--- a/taskcoachlib/gui/taskbaricon.py
+++ b/taskcoachlib/gui/taskbaricon.py
@@ -246,6 +246,6 @@ class TaskBarIcon(patterns.Observer, wx.adv.TaskBarIcon):
         icon = artprovider.getIcon(self.__bitmap)
         try:
             self.SetIcon(icon, self.__tooltipText)
-        except:
+        except Exception:
             # wx assert errors on macOS but the icon still gets set... Whatever
             pass

--- a/taskcoachlib/gui/uicommand/uicommand.py
+++ b/taskcoachlib/gui/uicommand/uicommand.py
@@ -2020,7 +2020,7 @@ class Mail(mixin_uicommand.NeedsSelectionMixin, ViewerCommand):
     def mail(self, to, cc, subject, body, mail, showerror):
         try:
             mail(to, subject, body, cc=cc)
-        except:
+        except Exception:
             # Try again with a dummy recipient:
             try:
                 mail("recipient@domain.com", subject, body)

--- a/taskcoachlib/gui/viewer/base.py
+++ b/taskcoachlib/gui/viewer/base.py
@@ -225,7 +225,7 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
                 imageList.Add(
                     wx.ArtProvider.GetBitmap(image, wx.ART_MENU, size)
                 )
-            except:
+            except Exception:
                 print(image)
                 raise
             self.imageIndex[image] = index

--- a/taskcoachlib/mailer/__init__.py
+++ b/taskcoachlib/mailer/__init__.py
@@ -50,7 +50,7 @@ def getSubject(message):
             encoding = "utf-8"
         try:
             return subject.decode(encoding)
-        except:
+        except (UnicodeDecodeError, LookupError):
             return repr(subject)
 
 
@@ -114,8 +114,8 @@ def openMail(filename):
                     try:
                         if openMailWithOutlook(filename):
                             return
-                    except:
-                        pass
+                    except Exception:
+                        pass  # Fall back to default handler
         finally:
             winreg.CloseKey(key)
 

--- a/taskcoachlib/mailer/macmail.py
+++ b/taskcoachlib/mailer/macmail.py
@@ -52,8 +52,8 @@ end tell
             if not sp.returncode:
                 self.__title = operating_system.decodeSystemString(out.strip())
                 return
-        except:
-            pass
+        except (OSError, subprocess.SubprocessError):
+            pass  # AppleScript execution failed
 
         self.__title = _("Mail.app message")
 

--- a/taskcoachlib/meta/debug.py
+++ b/taskcoachlib/meta/debug.py
@@ -82,8 +82,8 @@ def signature(func, args, kwargs, result):
     result = str(result)
     try:
         return "%s(%s, %s) -> %s" % (func, str(args), str(kwargs), result)
-    except:
-        return "%s(...) -> %s" % (func, result)  # pylint: disable=W0702
+    except Exception:
+        return "%s(...) -> %s" % (func, result)  # Args couldn't be stringified
 
 
 def format_traceback(frame):

--- a/taskcoachlib/meta/developermessagechecker.py
+++ b/taskcoachlib/meta/developermessagechecker.py
@@ -38,7 +38,7 @@ class DeveloperMessageChecker(threading.Thread):
     def run(self, show=True):  # pylint: disable=W0221
         try:
             message, url = self.__get_message()
-        except:  # pylint: disable=W0702
+        except Exception:
             return  # Whatever goes wrong, ignore it.
         if self.__message_is_new(message):
             return self.__notify_user(message, url, show)

--- a/taskcoachlib/meta/versionchecker.py
+++ b/taskcoachlib/meta/versionchecker.py
@@ -42,7 +42,7 @@ class VersionChecker(threading.Thread):
                 self.getLastVersionNotified()
             )
             currentVersion = self.tupleVersion(data.version)
-        except:
+        except Exception:
             if self.verbose:
                 self.notifyUser(
                     version.NoVersionDialog,

--- a/taskcoachlib/notify/notifier_growl.py
+++ b/taskcoachlib/notify/notifier_growl.py
@@ -36,8 +36,8 @@ class GrowlNotifier(AbstractNotifier):
                 applicationName=meta.name, notifications=["Reminder"]
             )
             self._notifier.register()
-        except:
-            self._available = False  # pylint: disable=W0702
+        except Exception:
+            self._available = False  # Growl registration failed
         else:
             self._available = True
 

--- a/taskcoachlib/notify/notifier_windows.py
+++ b/taskcoachlib/notify/notifier_windows.py
@@ -28,7 +28,7 @@ class SnarlNotifier(AbstractNotifier):
     def isAvailable(self):
         try:
             return bool(snarl.snGetVersion())
-        except:
+        except Exception:
             return False
 
     def notify(self, title, summary, bitmap, **kwargs):

--- a/taskcoachlib/persistence/autobackup.py
+++ b/taskcoachlib/persistence/autobackup.py
@@ -89,7 +89,7 @@ class BackupManifest(object):
                         ],
                     )
                 )
-            except:
+            except ValueError:
                 continue
             backups.append(date.DateTime(*tuple(comp)))
         return list(reversed(sorted(backups)))

--- a/taskcoachlib/persistence/csv/reader.py
+++ b/taskcoachlib/persistence/csv/reader.py
@@ -252,5 +252,5 @@ class CSVReader(object):
                 minute,
                 second,
             )
-        except:  # pylint: disable=W0702
+        except (ValueError, AttributeError):
             return None

--- a/taskcoachlib/persistence/sessiontempfile.py
+++ b/taskcoachlib/persistence/sessiontempfile.py
@@ -34,8 +34,8 @@ class TempFiles(object, metaclass=patterns.Singleton):
                 if os.name == "nt":
                     os.chmod(name, stat.S_IREAD | stat.S_IWRITE)
                 os.remove(name)
-            except:
-                pass  # pylint: disable=W0702
+            except OSError:
+                pass  # File may already be deleted or inaccessible
 
 
 def get_temp_file(**kwargs):

--- a/taskcoachlib/persistence/taskfile.py
+++ b/taskcoachlib/persistence/taskfile.py
@@ -482,7 +482,7 @@ class TaskFile(patterns.Observer):
                 xml.ChangesXMLWriter(
                     open(self.filename() + ".delta", "wb")
                 ).write(self.__changes)
-        except:
+        except Exception:
             self.setFilename("")
             raise
         finally:
@@ -494,8 +494,8 @@ class TaskFile(patterns.Observer):
     def save(self):
         try:
             pub.sendMessage("taskfile.aboutToSave", taskFile=self)
-        except:
-            pass
+        except Exception:
+            pass  # Ignore errors from subscribers
         # When encountering a problem while saving (disk full,
         # computer on fire), if we were writing directly to the file,
         # it's lost. So write to a temporary file and rename it if
@@ -523,8 +523,8 @@ class TaskFile(patterns.Observer):
             self.__notifier.saved()
             try:
                 pub.sendMessage("taskfile.justSaved", taskFile=self)
-            except:
-                pass
+            except Exception:
+                pass  # Ignore errors from subscribers
 
     def mergeDiskChanges(self):
         self.__loading = True
@@ -690,8 +690,8 @@ class LockedTaskFile(TaskFile):
                     location, mountPoint, fsType, options, a, b = (
                         line.strip().split()
                     )
-                except:
-                    pass
+                except ValueError:
+                    pass  # Skip malformed mount lines
                 if os.path.abspath(path).startswith(
                     mountPoint
                 ) and fsType.startswith("fuse."):

--- a/taskcoachlib/persistence/templatelist.py
+++ b/taskcoachlib/persistence/templatelist.py
@@ -63,7 +63,7 @@ class TemplateList(object):
         if os.path.exists(listName):
             try:
                 filenames = pickle.load(open(listName, "rb"))
-            except:
+            except (OSError, pickle.UnpicklingError, EOFError):
                 pass
         return filenames
 

--- a/taskcoachlib/persistence/todotxt/reader.py
+++ b/taskcoachlib/persistence/todotxt/reader.py
@@ -59,8 +59,8 @@ class TodoTxtReader(object):
                             line, todoTxtRE, keyValueRE, date.Now, None
                         )
                         self.__deletedTasks.add(taskId)
-                    except:
-                        pass  # Err
+                    except (ValueError, AttributeError):
+                        pass  # Skip invalid lines in meta file
                     metaLines[
                         "->".join(subjects) if self.__version == 0 else taskId
                     ] = line

--- a/taskcoachlib/widgets/draganddrop.py
+++ b/taskcoachlib/widgets/draganddrop.py
@@ -153,8 +153,8 @@ class DropTarget(wx.DropTarget):
         formatType = receivedFormat.GetType()
         try:
             formatId = receivedFormat.GetId()
-        except:
-            formatId = None  # pylint: disable=W0702
+        except RuntimeError:
+            formatId = None  # Format ID not available
         return formatType, formatId
 
     @staticmethod

--- a/taskcoachlib/widgets/password.py
+++ b/taskcoachlib/widgets/password.py
@@ -117,7 +117,7 @@ def _GetCachedPassword(domain, username, reset):
 def GetPassword(domain, username, reset=False):
     try:
         from keyring import set_password, get_password
-    except:
+    except ImportError:
         # Keychain unavailable.
         return _GetCachedPassword(domain, username, reset)
 

--- a/taskcoachlib/widgets/textctrl.py
+++ b/taskcoachlib/widgets/textctrl.py
@@ -150,7 +150,7 @@ class MultiLineTextCtrl(BaseTextCtrl):
         self.Bind(wx.EVT_TEXT_URL, self.onURLClicked)
         try:
             self.__webbrowser = webbrowser.get()
-        except:
+        except webbrowser.Error:
             self.__webbrowser = None
         self.MacCheckSpelling(self.CheckSpelling)
 

--- a/taskcoachlib/widgets/tooltip.py
+++ b/taskcoachlib/widgets/tooltip.py
@@ -293,7 +293,7 @@ class SimpleToolTip(ToolTipBase):
     def _drawTextLine(self, dc, textLine, x, y):
         try:
             dc.DrawText(textLine, x, y)
-        except:
+        except Exception:
             raise RuntimeError("Could not draw text %s" % repr(textLine))
         textHeight = dc.GetTextExtent(textLine)[1]
         return y + textHeight + 1

--- a/tests/disttests/win32/base.py
+++ b/tests/disttests/win32/base.py
@@ -52,8 +52,8 @@ class Window(object):
 
         try:
             win32gui.EnumChildWindows(self.hwnd, cb, None)
-        except:
-            result = []  # pylint: disable=W0702
+        except Exception:
+            result = []  # Window enumeration failed
         return result
 
     children = property(_get_children, doc="The window direct children")
@@ -214,8 +214,8 @@ class Win32TestCase(unittest.TestCase):
                 try:
                     if titleRegex.search(win32gui.GetWindowText(hwnd)):
                         windows.append(hwnd)
-                except:
-                    pass  # pylint: disable=W0702
+                except Exception:
+                    pass  # Window title matching failed
                 return True
 
             win32gui.EnumWindows(enumCb, None)

--- a/tests/unittests/persistenceTests/XMLReaderTest.py
+++ b/tests/unittests/persistenceTests/XMLReaderTest.py
@@ -163,8 +163,8 @@ class TempFileLockTest(XMLReaderTestCase):
             try:
                 os.remove(self.__filename)
                 os.remove(self.__filename + ".delta")
-            except:
-                pass  # pylint: disable=W0702
+            except OSError:
+                pass  # File removal may fail on Windows
 
             self.assertTrue(os.path.exists(self.__filename))
 


### PR DESCRIPTION
Replace bare 'except:' clauses with specific exception types for better error handling and code quality:

- config/settings.py: OSError, ValueError, SyntaxError, configparser errors
- persistence/*.py: OSError, ValueError, pickle errors, Exception for pub/sub
- gui/*.py: RuntimeError, ImportError, Exception for wx/GUI operations
- application/application.py: OSError, AttributeError, ImportError
- widgets/*.py: RuntimeError, ImportError, webbrowser.Error, Exception
- mailer/*.py: UnicodeDecodeError, LookupError, OSError, subprocess errors
- notify/*.py: Exception for notifier availability checks
- meta/*.py: Exception for version checking and debug utilities
- domain/date/scheduler.py: Exception for scheduled job execution
- tests/*.py: OSError, Exception for Windows GUI tests
- release.py: KeyError, IndexError for JSON parsing
- fixinit.py: ValueError for list.remove()

Third-party code in patches/ and taskcoachlib/thirdparty/ is not modified.