### PR TITLE
Fix Select All errors by filtering None values from curselection

### DIFF
--- a/taskcoachlib/gui/viewer/base.py
+++ b/taskcoachlib/gui/viewer/base.py
@@ -791,7 +791,7 @@ class TreeViewer(Viewer):  # pylint: disable=W0223
     def updateSelection(self, *args, **kwargs):
         super().updateSelection(*args, **kwargs)
         curselection = self.curselection()
-        if curselection:
+        if curselection and curselection[0] is not None:
             siblings = self.children(self.getItemParent(curselection[0]))
             self.__selectionIndex = (
                 siblings.index(curselection[0])
@@ -824,7 +824,7 @@ class TreeViewer(Viewer):  # pylint: disable=W0223
 
     def getItemParent(self, item):
         """Allow for overriding what the parent of an item is."""
-        return item.parent()
+        return item.parent() if item is not None else None
 
     def getItemExpanded(self, item):
         return item.isExpanded(context=self.settingsSection())

--- a/taskcoachlib/widgets/listctrl.py
+++ b/taskcoachlib/widgets/listctrl.py
@@ -180,9 +180,10 @@ class VirtualListCtrl(
         # Guard against deleted C++ object - can happen when wx.CallAfter
         # callback executes after window destruction (e.g., closing nested dialogs)
         try:
+            # Filter out None values - getItemWithIndex can return None for some indices
             return [
-                self.getItemWithIndex(index)
-                for index in self.__curselection_indices()
+                item for index in self.__curselection_indices()
+                if (item := self.getItemWithIndex(index)) is not None
             ]
         except RuntimeError:
             # wrapped C/C++ object has been deleted

--- a/taskcoachlib/widgets/treectrl.py
+++ b/taskcoachlib/widgets/treectrl.py
@@ -239,7 +239,12 @@ class TreeListCtrl(
         # Guard against deleted C++ object - can happen when wx.CallAfter
         # callback executes after window destruction (e.g., closing nested dialogs)
         try:
-            return [self.GetItemPyData(item) for item in self.GetSelections()]
+            # Filter out None values - GetItemPyData can return None for some items
+            # (e.g., root items or items without associated PyData)
+            return [
+                data for item in self.GetSelections()
+                if (data := self.GetItemPyData(item)) is not None
+            ]
         except RuntimeError:
             # wrapped C/C++ object has been deleted
             return []


### PR DESCRIPTION
The Select All function was causing AttributeError when GetItemPyData() or getItemWithIndex() returned None for some items. This occurred in tree views (main window, categories panel) but not effort panel.

Changes:
- treectrl.py: Filter out None values from curselection() results
- listctrl.py: Filter out None values from curselection() results
- base.py: Add defensive None checks in updateSelection() and getItemParent()