### PR TITLE
Fix Effort comparison error when efforts have identical start times

### DIFF
--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -24,8 +24,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # IMPORTANT: Always increment version_patch with each change/commit!
 
 version = "1.6.1"  # Current version number of the application
-version_patch = "9"  # Patch level - INCREMENT THIS WITH EACH CHANGE!
-version_full = f"{version}.{version_patch}"  # Full version string: 1.6.1.9
+version_patch = "10"  # Patch level - INCREMENT THIS WITH EACH CHANGE!
+version_full = f"{version}.{version_patch}"  # Full version string: 1.6.1.10
 
 
 def _get_git_commit_hash():
@@ -56,8 +56,9 @@ def _get_git_commit_hash():
 
 
 # Get git commit hash dynamically (empty string if not available)
-version_commit = _get_git_commit_hash()
-git_commit_hash = version_commit
+git_commit_hash = _get_git_commit_hash()
+# For display purposes, show "(n/a)" if no commit hash available
+version_commit = git_commit_hash if git_commit_hash else "(n/a)"
 
 tskversion = 37  # Current version number of the task file format, changed to 37 for release 1.3.23.
 release_day = "23"  # Day number of the release, 1-31, as string


### PR DESCRIPTION
Add comparison operators (__eq__, __lt__, __hash__) to Effort class to fix TypeError when comparing Effort objects. This error occurs when loading files with efforts that have identical start times, as Python falls back to comparing Effort objects during collection operations.

Also fix version display to show "(n/a)" instead of empty string when running outside of a git repository.

Version: 1.6.1.10