### PR TITLE
Fix log startup separator to have bars on both sides

### DIFF
--- a/taskcoachlib/application/application.py
+++ b/taskcoachlib/application/application.py
@@ -397,6 +397,10 @@ class Application(object, metaclass=patterns.Singleton):
         from taskcoachlib import meta
         import platform
 
+        # Log session start with date/time centered in separator
+        date_str = datetime.datetime.now().strftime("%a %b %d %H:%M:%S %Y")
+        log_message(f" {date_str} ".center(60, "="))
+
         # Log version info at startup for debugging
         if meta.git_commit_hash:
             log_message(f"Task Coach {meta.version_full} (commit {meta.git_commit_hash})")

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -24,7 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # IMPORTANT: Always increment version_patch AND update release_day/release_month below!
 
 version = "1.6.1"  # Current version number of the application
-version_patch = "66"  # Patch level - INCREMENT THIS AND UPDATE DATE BELOW!
+version_patch = "67"  # Patch level - INCREMENT THIS AND UPDATE DATE BELOW!
 version_full = f"{version}.{version_patch}"  # Full version string: 1.6.1.11
 
 


### PR DESCRIPTION
The date/time line now has = bars on both sides and is centered to match the 60-character width of other separator lines:

  ============== Sat Dec 20 11:25:06 2025 ==============