### PR TITLE
Add GTK scale factor and idle detection warnings to ignore patterns

### DIFF
--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -24,7 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # IMPORTANT: Always increment version_patch AND update release_day/release_month below!
 
 version = "1.6.1"  # Current version number of the application
-version_patch = "69"  # Patch level - INCREMENT THIS AND UPDATE DATE BELOW!
+version_patch = "70"  # Patch level - INCREMENT THIS AND UPDATE DATE BELOW!
 version_full = f"{version}.{version_patch}"  # Full version string: 1.6.1.11
 
 

--- a/taskcoachlib/tee.py
+++ b/taskcoachlib/tee.py
@@ -33,6 +33,10 @@ STDERR_IGNORE_PATTERNS = (
     # wxPython debug messages about duplicate handlers, harmless
     "Adding duplicate image handler",
     "Adding duplicate animation handler",
+    # GTK scale factor assertion on multi-monitor setups, harmless
+    "gtk_widget_get_scale_factor",
+    # Idle detection unavailable on KDE Wayland (no simple DBus API available)
+    "Idle time detection unavailable",
 )
 
 


### PR DESCRIPTION
- gtk_widget_get_scale_factor: harmless GTK3 assertion on multi-monitor setups
- Idle time detection unavailable: expected on KDE Wayland where no simple DBus API exists (GetSessionIdleTime deliberately returns error since Plasma 5.27, and ext-idle-notify-v1 requires native Wayland integration)