### PR TITLE
Fix reminder dialog crash due to incorrect sizer parent

### DIFF
--- a/taskcoachlib/gui/dialog/reminder.py
+++ b/taskcoachlib/gui/dialog/reminder.py
@@ -82,7 +82,6 @@ class ReminderDialog(patterns.Observer, sized_controls.SizedDialog):
             wx.StaticText(pane, label=label)
 
         self.snoozeOptions = wx.ComboBox(pane, style=wx.CB_READONLY)
-        sizer.Add(self.snoozeOptions, flag=wx.ALIGN_CENTER_VERTICAL)
         snoozeTimesUserWantsToSee = [0] + self.settings.getlist(
             "view", "snoozetimes"
         )


### PR DESCRIPTION
The snoozeOptions ComboBox was being added to the wrong sizer - it was added to the horizontal sizer belonging to the task/tracking panel, but the ComboBox was created with the pane as its parent. This caused a wxAssertionError about mismatched window parents.

Since snoozeOptions is a child of the pane (which uses a form sizer), it's automatically laid out correctly and doesn't need to be manually added to a sizer.